### PR TITLE
increase timeout to 5 minutes to have more time for the login

### DIFF
--- a/kubectl-login.go
+++ b/kubectl-login.go
@@ -215,7 +215,7 @@ func runOidc(host string) {
 	oidc.httpServer = &http.Server{Addr: "127.0.0.1:8400", Handler: m}
 
 	go func() {
-		time.Sleep(30 * time.Second)
+		time.Sleep(5 * time.Minute)
 		fmt.Println("Timeout wating for login")
 		os.Exit(1)
 


### PR DESCRIPTION
Hi!

In our company we ran in quite a lot of timeouts because of 2FA and so on often taking more than 30 seconds. I see no reason to keep this timeout that low, so I increased it to 5 minutes. Would be nice if this gets merged and released.

Thanks!